### PR TITLE
Merged improvements: temp fix, fan/vane mapping, wireless sensor, diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,30 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [1.0.0] - 2024-01-01
+## [1.1.0] - 2026-03-09
 
 ### Added
-- Initial release of Mitsubishi Comfort integration
-- Climate control support for Mitsubishi Electric systems via Kumo Cloud API
-- Config flow for easy setup
-- Multi-zone support
-- Automatic token refresh
-- Device capability detection
-- Support for temperature, HVAC modes, fan speeds, and air direction
-- Real-time temperature and humidity monitoring
+- Mitsubishi proprietary F/C temperature lookup tables (ekiczek PR #23, PR #199)
+- Fan speed mapping: API values now correctly translate to Comfort app labels
+- Vane position mapping: API values now correctly translate to Comfort app labels
+- Command caching with `updatedAt` comparison to prevent state bounce (smack000)
+- Standalone temperature and humidity sensor entities per zone (smack000)
+- Wireless sensor support: battery level, signal strength (RSSI), temperature, and humidity
+  from PAC-USWHS003-TH-1 sensors via /v3/devices/{serial}/sensor endpoint
+- Diagnostic sensors: WiFi adapter firmware version and signal strength via /v3/devices/{serial}/status
+- Filter maintenance tracking via /v3/zones/{id}/notification-preferences
+- Updated API app version from 3.0.9 to 3.2.4 to match current Comfort app
+- Auto heat/cool mode with dual setpoint support (smack000 / tw3rp)
+- Refactored architecture: API client and coordinator in separate modules (smack000)
+- API retry logic with exponential backoff for 429 rate limits (smack000 / tw3rp)
+- Improved entity availability: prevents false automation triggers during transient API errors (tw3rp)
+- Debug logging for fan speed and vane position translations
 
-### Features
-- Climate entity with full Home Assistant integration
-- Automatic discovery of zones within selected site
-- Configurable update intervals
-- Error handling and retry logic
-- Support for multiple HVAC modes (heat, cool, dry, fan, auto)
-- Device-specific feature detection 
+### Fixed
+- Temperature setpoints now match the Comfort app exactly (no more ~1 F drift)
+- Fan speed display matches Comfort app labels (was showing raw API values)
+- Vane position display matches Comfort app labels (was showing raw API values)
+- State bouncing after sending commands (cached commands maintained until server confirms)
+- Sensor entities now inherit from CoordinatorEntity for automatic updates
+
+## [0.1.1-alpha.1] - Previous upstream release
+- Initial Kumo Cloud V3 API integration by jjustinwilson

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Same issue. Raw API values like `midvertical` and `midhorizontal` are translated
 ### Temperature conversion
 Mitsubishi uses a proprietary F-to-C lookup table that diverges from standard math at several setpoints (64-66 F, 69-72 F). This fork uses the same lookup table as the Comfort app, eliminating the ~1 F drift for Fahrenheit users. Based on [ekiczek's work](https://github.com/ekiczek/comfort_HA) (PR #23).
 
+### Wireless sensor support (PAC-USWHS003-TH-1)
+For zones with a Mitsubishi wireless temperature/humidity sensor attached, the integration creates additional entities for battery level, signal strength (RSSI), and the wireless sensor's own temperature and humidity readings. The `hasSensor` flag in the zone data is used to detect which devices have a wireless sensor, and the data is fetched from the `/v3/devices/{serial}/sensor` endpoint (discovered via traffic analysis of the Comfort app).
+
 ### Command caching / anti-bounce
 The Comfort cloud API can take up to a minute to reflect changes from sent commands. Previous code that queried a second after issuing a command would "bounce" the state back to what it was before. This fork caches commands with timestamps and examines the `updatedAt` field returned by the server to keep queued commands applied until a server update confirms the command was processed. Based on [smack000's work](https://github.com/smack000/comfort_HA).
 
@@ -23,9 +26,6 @@ Proper support for Mitsubishi's `autoCool` and `autoHeat` operation modes, mappe
 
 ### Temperature and humidity sensors
 Standalone sensor entities for each zone, usable in automations, history graphs, and dashboard cards independently from the climate entity.
-
-### Wireless sensor support (PAC-USWHS003-TH-1)
-For zones with a Mitsubishi wireless temperature/humidity sensor attached, the integration creates additional entities for battery level, signal strength (RSSI), and the wireless sensor's own temperature and humidity readings. The `hasSensor` flag in the zone data is used to detect which devices have a wireless sensor, and the data is fetched from the `/v3/devices/{serial}/sensor` endpoint (discovered via traffic analysis of the Comfort app).
 
 ### Diagnostic sensors
 WiFi adapter firmware version and signal strength (RSSI) from the `/v3/devices/{serial}/status` endpoint, plus filter maintenance reminders from `/v3/zones/{id}/notification-preferences`. All exposed as diagnostic entities.

--- a/README.md
+++ b/README.md
@@ -1,82 +1,86 @@
 # Mitsubishi Comfort Integration for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
-[![GitHub release](https://img.shields.io/github/release/jjustinwilson/kumo_cloud.svg)](https://github.com/jjustinwilson/kumo_cloud/releases)
 
-This integration allows you to control your Mitsubishi Electric climate control systems through the Kumo Cloud API in Home Assistant.
+Fork of [jjustinwilson/comfort_HA](https://github.com/jjustinwilson/comfort_HA) with the following fixes and enhancements:
+
+## What's different in this fork
+
+### Fan speed mapping
+The upstream integration passes raw Kumo Cloud API values (`quiet`, `low`, `powerful`) that don't match what the Comfort app or physical remote shows. This fork translates them to match the app labels (Quiet, Low, Medium, High, Powerful).
+
+### Vane position mapping
+Same issue. Raw API values like `midvertical` and `midhorizontal` are translated to the Comfort app labels (Lowest, Low, Middle, High, Highest).
+
+### Temperature conversion
+Mitsubishi uses a proprietary F-to-C lookup table that diverges from standard math at several setpoints (64-66 F, 69-72 F). This fork uses the same lookup table as the Comfort app, eliminating the ~1 F drift for Fahrenheit users. Based on [ekiczek's work](https://github.com/ekiczek/comfort_HA) (PR #23).
+
+### Command caching / anti-bounce
+The Comfort cloud API can take up to a minute to reflect changes from sent commands. Previous code that queried a second after issuing a command would "bounce" the state back to what it was before. This fork caches commands with timestamps and examines the `updatedAt` field returned by the server to keep queued commands applied until a server update confirms the command was processed. Based on [smack000's work](https://github.com/smack000/comfort_HA).
+
+### Auto heat/cool mode
+Proper support for Mitsubishi's `autoCool` and `autoHeat` operation modes, mapped to HA's `HEAT_COOL` mode with dual setpoint support (separate heat and cool target temperatures).
+
+### Temperature and humidity sensors
+Standalone sensor entities for each zone, usable in automations, history graphs, and dashboard cards independently from the climate entity.
+
+### Wireless sensor support (PAC-USWHS003-TH-1)
+For zones with a Mitsubishi wireless temperature/humidity sensor attached, the integration creates additional entities for battery level, signal strength (RSSI), and the wireless sensor's own temperature and humidity readings. The `hasSensor` flag in the zone data is used to detect which devices have a wireless sensor, and the data is fetched from the `/v3/devices/{serial}/sensor` endpoint (discovered via traffic analysis of the Comfort app).
+
+### Diagnostic sensors
+WiFi adapter firmware version and signal strength (RSSI) from the `/v3/devices/{serial}/status` endpoint, plus filter maintenance reminders from `/v3/zones/{id}/notification-preferences`. All exposed as diagnostic entities.
+
+### Refactored architecture
+API client and coordinator extracted into separate modules (`api.py`, `coordinator.py`), eliminating blocking load dependencies between the climate and sensor platforms. Includes retry logic with exponential backoff for API rate limits (429 errors).
 
 ## Installation
 
 ### HACS (Recommended)
 
-1. Install [HACS](https://hacs.xyz/) if you haven't already
-2. Go to HACS → Integrations
-3. Click the three dots in the top right corner and select "Custom repositories"
-4. Add this repository URL: `https://github.com/jjustinwilson/comfort_HA/`
-5. Select "Integration" as the category
-6. Click "Add"
-7. Find "Mitsubishi Comfort" in the HACS integrations list and install it
-8. Restart Home Assistant
+1. Install [HACS](https://hacs.xyz) if you haven't already
+2. Go to HACS > Integrations > 3 dots menu > Custom repositories
+3. Add `JoeQuantum/comfort_HA` with category "Integration"
+4. Search for "Mitsubishi Comfort" and install
+5. Restart Home Assistant
+
+### Manual
+
+1. Copy the `custom_components/kumo_cloud` folder to your HA `custom_components` directory
+2. Restart Home Assistant
 
 ## Configuration
 
-1. Go to **Settings** > **Devices & Services** > **Add Integration**
+1. Go to Settings > Devices & Services > Add Integration
 2. Search for "Mitsubishi Comfort"
-3. Enter your Kumo Cloud account credentials (email and password)
-4. Select the site you want to control if you have multiple sites
-5. Your climate devices will be automatically discovered and added
+3. Enter your Kumo Cloud / Comfort app credentials
+4. Select your site if you have multiple
 
-## Features
+## Fan Speed Reference
 
-- **Climate Control**: Control temperature, HVAC modes (heat, cool, dry, fan, auto), fan speeds, and air direction
-- **Real-time Updates**: Monitor current temperature, humidity, and device status
-- **Multi-Zone Support**: Control multiple zones within a site
-- **Automatic Token Refresh**: Handles authentication token refresh automatically
-- **Device Profiles**: Automatically detects device capabilities and adjusts available features
+| HA Label | Comfort App | API Value |
+|----------|-------------|-----------|
+| auto     | Auto        | auto      |
+| quiet    | Quiet       | superQuiet |
+| low      | Low         | quiet     |
+| medium   | Medium      | low       |
+| high     | High        | powerful  |
+| powerful | Powerful    | superPowerful |
 
-## Supported HVAC Modes
+## Vane Position Reference
 
-- **Off**: Turn the unit off
-- **Cool**: Cooling mode
-- **Heat**: Heating mode (if supported by device)
-- **Dry**: Dehumidification mode (if supported by device)
-- **Fan Only**: Fan only mode (if supported by device)
-- **Auto**: Automatic heating/cooling mode (if supported by device)
+| HA Label | Comfort App | API Value |
+|----------|-------------|-----------|
+| auto     | Auto        | auto      |
+| swing    | Swing       | swing     |
+| lowest   | Lowest      | vertical  |
+| low      | Low         | midvertical |
+| middle   | Middle      | midpoint  |
+| high     | High        | midhorizontal |
+| highest  | Highest     | horizontal |
 
-## Supported Features
+## Credits
 
-- **Temperature Control**: Set target temperature with 0.5°C precision
-- **Fan Speed Control**: Auto, Low, Medium, High (depending on device capabilities)
-- **Air Direction Control**: Horizontal, Vertical, Swing (if supported by device)
-- **Current Temperature**: Monitor room temperature
-- **Humidity Monitoring**: View current humidity levels
-
-## API Information
-
-This integration uses the unofficial Kumo Cloud API v3. The API endpoints and schemas were reverse-engineered from the mobile app and may change without notice.
-
-## Troubleshooting
-
-- **Authentication Errors**: Verify your Kumo Cloud credentials are correct
-- **Connection Issues**: Check your internet connection and ensure the Kumo Cloud service is available
-- **Device Not Responding**: Check that your climate control system is connected to Wi-Fi and online in the Kumo Cloud app
-
-## Technical Details
-
-- **Update Interval**: 60 seconds (configurable)
-- **Token Refresh**: Automatic every 20 minutes
-- **Temperature Unit**: Celsius (as used by the Kumo Cloud API)
-- **API Base URL**: https://app-prod.kumocloud.com
-- **API Version**: v3
-
-## Support
-
-If you encounter any issues, please check the [issue tracker](https://github.com/jjustinwilson/comfort_HA/issues) or create a new issue with details about your problem.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-## License
-
-This project is licensed under the MIT License. 
+- [jjustinwilson](https://github.com/jjustinwilson/comfort_HA) - Original integration and V3 API reverse engineering
+- [ekiczek](https://github.com/ekiczek/comfort_HA) - Mitsubishi F/C temperature lookup tables (PR #23, hass-kumo PR #199)
+- [smack000](https://github.com/smack000/comfort_HA) - Command caching, coordinator refactor, sensors, auto heat/cool mode
+- [tw3rp](https://github.com/jjustinwilson/comfort_HA/pull/2#issuecomment-2974732965) - Dual setpoint support for auto heat/cool, improved entity availability, API rate limiting with exponential backoff

--- a/custom_components/kumo_cloud/__init__.py
+++ b/custom_components/kumo_cloud/__init__.py
@@ -2,24 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import timedelta
-from typing import Any
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import KumoCloudAPI, KumoCloudAuthError, KumoCloudConnectionError
-from .const import CONF_SITE_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .coordinator import KumoCloudDataUpdateCoordinator
+from .const import CONF_SITE_ID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE]
-
+PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kumo Cloud from a config entry."""
@@ -72,195 +67,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class KumoCloudDataUpdateCoordinator(DataUpdateCoordinator):
-    """Class to manage fetching Kumo Cloud data."""
-
-    def __init__(self, hass: HomeAssistant, api: KumoCloudAPI, site_id: str) -> None:
-        """Initialize the coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
-        )
-        self.api = api
-        self.site_id = site_id
-        self.zones: list[dict[str, Any]] = []
-        self.devices: dict[str, dict[str, Any]] = {}
-        self.device_profiles: dict[str, list[dict[str, Any]]] = {}
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from Kumo Cloud."""
-        try:
-            # Get zones for the site
-            zones = await self.api.get_zones(self.site_id)
-
-            # Get device details for each zone
-            devices = {}
-            device_profiles = {}
-
-            for zone in zones:
-                if "adapter" in zone and zone["adapter"]:
-                    device_serial = zone["adapter"]["deviceSerial"]
-
-                    # Get device details and profile in parallel
-                    device_detail_task = self.api.get_device_details(device_serial)
-                    device_profile_task = self.api.get_device_profile(device_serial)
-
-                    device_detail, device_profile = await asyncio.gather(
-                        device_detail_task, device_profile_task
-                    )
-
-                    devices[device_serial] = device_detail
-                    device_profiles[device_serial] = device_profile
-
-            # Store the data for access by entities
-            self.zones = zones
-            self.devices = devices
-            self.device_profiles = device_profiles
-
-            return {
-                "zones": zones,
-                "devices": devices,
-                "device_profiles": device_profiles,
-            }
-
-        except KumoCloudAuthError as err:
-            # Try to refresh token once
-            try:
-                await self.api.refresh_access_token()
-                # Retry the request
-                return await self._async_update_data()
-            except KumoCloudAuthError as refresh_err:
-                raise UpdateFailed(
-                    f"Authentication failed: {refresh_err}"
-                ) from refresh_err
-        except KumoCloudConnectionError as err:
-            raise UpdateFailed(f"Error communicating with API: {err}") from err
-        except Exception as err:
-            raise UpdateFailed(f"Unexpected error: {err}") from err
-
-    async def async_refresh_device(self, device_serial: str) -> None:
-        """Refresh a specific device's data immediately."""
-        try:
-            # Get fresh device details
-            device_detail = await self.api.get_device_details(device_serial)
-
-            # Update the cached device data
-            self.devices[device_serial] = device_detail
-
-            # Also update the zone data if it contains the same info
-            for zone in self.zones:
-                if "adapter" in zone and zone["adapter"]:
-                    if zone["adapter"]["deviceSerial"] == device_serial:
-                        # Update adapter data with fresh device data
-                        zone["adapter"].update(
-                            {
-                                "roomTemp": device_detail.get("roomTemp"),
-                                "operationMode": device_detail.get("operationMode"),
-                                "power": device_detail.get("power"),
-                                "fanSpeed": device_detail.get("fanSpeed"),
-                                "airDirection": device_detail.get("airDirection"),
-                                "spCool": device_detail.get("spCool"),
-                                "spHeat": device_detail.get("spHeat"),
-                                "humidity": device_detail.get("humidity"),
-                            }
-                        )
-                        break
-
-            # Update the coordinator's data dict
-            self.data = {
-                "zones": self.zones,
-                "devices": self.devices,
-                "device_profiles": self.device_profiles,
-            }
-
-            # Notify all listeners that data has been updated
-            self.async_update_listeners()
-
-            _LOGGER.debug("Refreshed device %s data", device_serial)
-
-        except Exception as err:
-            _LOGGER.warning("Failed to refresh device %s: %s", device_serial, err)
-
-
-class KumoCloudDevice:
-    """Representation of a Kumo Cloud device."""
-
-    def __init__(
-        self,
-        coordinator: KumoCloudDataUpdateCoordinator,
-        zone_id: str,
-        device_serial: str,
-    ) -> None:
-        """Initialize the device."""
-        self.coordinator = coordinator
-        self.zone_id = zone_id
-        self.device_serial = device_serial
-        self._zone_data: dict[str, Any] | None = None
-        self._device_data: dict[str, Any] | None = None
-        self._profile_data: list[dict[str, Any]] | None = None
-
-    @property
-    def zone_data(self) -> dict[str, Any]:
-        """Get the zone data."""
-        # Always get fresh data from coordinator
-        for zone in self.coordinator.zones:
-            if zone["id"] == self.zone_id:
-                return zone
-        return {}
-
-    @property
-    def device_data(self) -> dict[str, Any]:
-        """Get the device data."""
-        # Always get fresh data from coordinator
-        return self.coordinator.devices.get(self.device_serial, {})
-
-    @property
-    def profile_data(self) -> list[dict[str, Any]]:
-        """Get the device profile data."""
-        # Always get fresh data from coordinator
-        return self.coordinator.device_profiles.get(self.device_serial, [])
-
-    @property
-    def available(self) -> bool:
-        """Return True if device is available."""
-        adapter = self.zone_data.get("adapter", {})
-        device_data = self.device_data
-
-        # Check both adapter and device data for connection status
-        adapter_connected = adapter.get("connected", False)
-        device_connected = device_data.get("connected", adapter_connected)
-
-        return device_connected
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self.zone_data.get("name", f"Zone {self.zone_id}")
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID for the device."""
-        return f"{self.device_serial}_{self.zone_id}"
-
-    async def send_command(self, commands: dict[str, Any]) -> None:
-        """Send a command to the device and refresh status."""
-        try:
-            # Send the command
-            await self.coordinator.api.send_command(self.device_serial, commands)
-            _LOGGER.debug("Sent command to device %s: %s", self.device_serial, commands)
-
-            # Wait a moment for the command to be processed
-            await asyncio.sleep(1)
-
-            # Refresh this specific device's data immediately
-            await self.coordinator.async_refresh_device(self.device_serial)
-
-        except Exception as err:
-            _LOGGER.error(
-                "Failed to send command to device %s: %s", self.device_serial, err
-            )
-            raise

--- a/custom_components/kumo_cloud/api.py
+++ b/custom_components/kumo_cloud/api.py
@@ -154,27 +154,51 @@ class KumoCloudAPI:
             "Content-Type": "application/json",
         }
 
-        try:
-            async with asyncio.timeout(30):
-                if method.upper() == "GET":
-                    async with self.session.get(url, headers=headers) as response:
-                        response.raise_for_status()
-                        return await response.json()
-                elif method.upper() == "POST":
-                    async with self.session.post(
-                        url, headers=headers, json=data
-                    ) as response:
-                        response.raise_for_status()
-                        if response.content_type == "application/json":
+        max_retries = 3
+        base_delay = 60
+        
+        for attempt in range(max_retries + 1):
+            try:
+                async with asyncio.timeout(30):
+                    if method.upper() == "GET":
+                        async with self.session.get(url, headers=headers) as response:
+                            response.raise_for_status()
                             return await response.json()
-                        return {}
+                    elif method.upper() == "POST":
+                        async with self.session.post(
+                            url, headers=headers, json=data
+                        ) as response:
+                            response.raise_for_status()
+                            if response.content_type == "application/json":
+                                return await response.json()
+                            return {}
 
-        except asyncio.TimeoutError as err:
-            raise KumoCloudConnectionError("Request timeout") from err
-        except ClientResponseError as err:
-            if err.status == 401:
-                raise KumoCloudAuthError("Authentication failed") from err
-            raise KumoCloudConnectionError(f"HTTP error: {err.status}") from err
+            except asyncio.TimeoutError as err:
+                if attempt < max_retries:
+                    delay = base_delay * (2 ** attempt)
+                    _LOGGER.warning(
+                        "Request timeout (attempt %d/%d), retrying in %d seconds",
+                        attempt + 1,
+                        max_retries + 1,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise KumoCloudConnectionError("Request timeout") from err
+            except ClientResponseError as err:
+                if err.status == 401:
+                    raise KumoCloudAuthError("Authentication failed") from err
+                if err.status == 429 and attempt < max_retries:
+                    delay = base_delay * (2 ** attempt)
+                    _LOGGER.warning(
+                        "Rate limited (429), retrying in %d seconds (attempt %d/%d)",
+                        delay,
+                        attempt + 1,
+                        max_retries + 1,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise KumoCloudConnectionError(f"HTTP error: {err.status}") from err
 
     async def get_account_info(self) -> dict[str, Any]:
         """Get account information."""
@@ -195,6 +219,47 @@ class KumoCloudAPI:
     async def get_device_profile(self, device_serial: str) -> list[dict[str, Any]]:
         """Get device profile information."""
         return await self._request("GET", f"/devices/{device_serial}/profile")
+
+    async def get_wireless_sensor(self, device_serial: str) -> dict[str, Any] | None:
+        """Get wireless sensor data (battery, temperature, humidity, rssi).
+
+        Returns None if the device has no wireless sensor attached.
+        Endpoint: GET /v3/devices/{deviceSerial}/sensor
+        """
+        try:
+            return await self._request("GET", f"/devices/{device_serial}/sensor")
+        except KumoCloudConnectionError as err:
+            if "404" in str(err):
+                return None
+            raise
+
+    async def get_device_status(self, device_serial: str) -> dict[str, Any] | None:
+        """Get device status (firmware version, WiFi signal, router info).
+
+        Endpoint: GET /v3/devices/{deviceSerial}/status
+        Returns: firmwareVersion, routerSsid, routerRssi, autoModeDisable,
+                 roomTempDisplayOffset, modeHeat, modeDry, cryptoSerial, etc.
+        """
+        try:
+            return await self._request("GET", f"/devices/{device_serial}/status")
+        except KumoCloudConnectionError as err:
+            if "404" in str(err):
+                return None
+            raise
+
+    async def get_zone_notification_preferences(self, zone_id: str) -> dict[str, Any] | None:
+        """Get zone notification preferences (filter reminders, alert settings).
+
+        Endpoint: GET /v3/zones/{zoneId}/notification-preferences
+        Returns: filterDirtyReminderInterval, filterDirtyReminderLastSent,
+                 sensorLowBattery, sensorSignalLost, lowTemp, highTemp, etc.
+        """
+        try:
+            return await self._request("GET", f"/zones/{zone_id}/notification-preferences")
+        except KumoCloudConnectionError as err:
+            if "404" in str(err):
+                return None
+            raise
 
     async def send_command(
         self, device_serial: str, commands: dict[str, Any]

--- a/custom_components/kumo_cloud/climate.py
+++ b/custom_components/kumo_cloud/climate.py
@@ -373,16 +373,17 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
         profile = self.device.profile_data
         if profile:
             profile_data = profile[0] if isinstance(profile, list) else profile
+            max_setpoints = profile_data.get("maximumSetPoints", {})
 
-            if profile_data.get("hasModeHeat", False):
+            if profile_data.get("hasModeHeat", False) or "heat" in max_setpoints:
                 modes.append(HVACMode.HEAT)
-            if profile_data.get("hasModeCool", False):
+            if profile_data.get("hasModeCool", False) or "cool" in max_setpoints:
                 modes.append(HVACMode.COOL)
             if profile_data.get("hasModeDry", False):
                 modes.append(HVACMode.DRY)
-            if profile_data.get("hasModeFan", False):
+            if profile_data.get("hasModeFan", False) or profile_data.get("hasModeVent", False):
                 modes.append(HVACMode.FAN_ONLY)
-            if profile_data.get("hasModeAuto", False):
+            if profile_data.get("hasModeAuto", False) or "auto" in max_setpoints:
                 modes.append(HVACMode.HEAT_COOL)
         else:
             modes.extend([HVACMode.HEAT, HVACMode.COOL])

--- a/custom_components/kumo_cloud/climate.py
+++ b/custom_components/kumo_cloud/climate.py
@@ -1,4 +1,12 @@
-"""Platform for Kumo Cloud climate integration."""
+"""Platform for Kumo Cloud climate integration.
+
+Merged from multiple forks:
+- smack000: Command caching, anti-bounce, coordinator refactor, auto heat/cool,
+  humidity attribute, power-based off detection
+- ekiczek: Mitsubishi proprietary F/C temperature lookup tables (PR #23, PR #199)
+- tw3rp: Dual setpoint support, improved entity availability, API rate limiting
+- Fan/vane UI mapping: Correct Comfort app labels for fan speeds and vane positions
+"""
 
 from __future__ import annotations
 
@@ -11,6 +19,10 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
@@ -18,7 +30,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import KumoCloudDataUpdateCoordinator, KumoCloudDevice
+from .coordinator import KumoCloudDataUpdateCoordinator, KumoCloudDevice
 from .const import (
     DOMAIN,
     OPERATION_MODE_OFF,
@@ -27,6 +39,8 @@ from .const import (
     OPERATION_MODE_DRY,
     OPERATION_MODE_VENT,
     OPERATION_MODE_AUTO,
+    OPERATION_MODE_AUTO_COOL,
+    OPERATION_MODE_AUTO_HEAT,
     FAN_SPEED_AUTO,
     FAN_SPEED_LOW,
     FAN_SPEED_MEDIUM,
@@ -38,7 +52,125 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Mapping from Kumo Cloud operation modes to Home Assistant HVAC modes
+
+# =============================================================================
+# Mitsubishi proprietary F<->C temperature conversion
+# =============================================================================
+# Mitsubishi systems use 0.5 C steps internally, but their F-to-C mapping
+# diverges from standard math at several points (64-66 F and 69-72 F).
+# This lookup table matches the Comfort app and physical thermostat exactly,
+# eliminating the ~1 F drift that standard rounding causes for Fahrenheit users.
+# Source: ekiczek/comfort_HA PR #23, dlarrick/hass-kumo PR #199
+
+_F_TO_C: dict[int, float] = {
+    61: 16.0, 62: 16.5, 63: 17.0, 64: 17.5, 65: 18.0, 66: 18.5,
+    67: 19.5, 68: 20.0, 69: 21.0, 70: 21.5, 71: 22.0, 72: 22.5,
+    73: 23.0, 74: 23.5, 75: 24.0, 76: 24.5, 77: 25.0, 78: 25.5,
+    79: 26.0, 80: 26.5,
+}
+
+# Celsius-to-Fahrenheit lookup for display. This is NOT a simple inverse of
+# _F_TO_C because Mitsubishi's C->F mapping for room temperature display
+# differs from the setpoint mapping at certain values (e.g. 19.0 C = 67 F
+# for display, but 67 F = 19.5 C for setpoints).
+_C_TO_F: dict[float, int] = {
+    16.0: 61, 16.5: 62, 17.0: 63, 17.5: 64, 18.0: 65, 18.5: 66,
+    19.0: 67, 19.5: 67, 20.0: 68, 20.5: 69,
+    21.0: 69, 21.5: 70, 22.0: 71, 22.5: 72,
+    23.0: 73, 23.5: 74, 24.0: 75, 24.5: 76, 25.0: 77, 25.5: 78,
+    26.0: 79, 26.5: 80,
+}
+
+
+def _c_to_f(celsius: float | None) -> float | None:
+    """Convert Celsius to Fahrenheit using Mitsubishi's lookup table.
+
+    Falls back to standard rounding for values outside the table
+    (e.g. current room temperature readings that may not be exact setpoints).
+    """
+    if celsius is None:
+        return None
+    if celsius in _C_TO_F:
+        return _C_TO_F[celsius]
+    return round(celsius * 9.0 / 5.0 + 32.0)
+
+
+def _f_to_c(fahrenheit: float | None) -> float | None:
+    """Convert Fahrenheit to Celsius using Mitsubishi's lookup table.
+
+    Falls back to standard rounding for values outside the table.
+    """
+    if fahrenheit is None:
+        return None
+    f_int = int(round(fahrenheit))
+    if f_int in _F_TO_C:
+        return _F_TO_C[f_int]
+    celsius = (fahrenheit - 32.0) * 5.0 / 9.0
+    return round(celsius * 2.0) / 2.0
+
+
+# =============================================================================
+# Fan speed mapping: Kumo Cloud API values <-> Comfort app UI labels
+# =============================================================================
+# The V3 API uses internal speed names that don't match what the Comfort app
+# or physical remote displays. This mapping translates between the two.
+
+API_TO_UI_FAN = {
+    "auto": "auto",
+    "superQuiet": "quiet",       # vendor "superQuiet"    -> UI "quiet"
+    "quiet": "low",              # vendor "quiet"         -> UI "low"
+    "low": "medium",             # vendor "low"           -> UI "medium"
+    "powerful": "high",          # vendor "powerful"      -> UI "high"
+    "superPowerful": "powerful", # vendor "superPowerful" -> UI "powerful"
+}
+UI_TO_API_FAN = {
+    "auto": "auto",
+    "quiet": "superQuiet",
+    "low": "quiet",
+    "medium": "low",
+    "high": "powerful",
+    "powerful": "superPowerful",
+}
+# Order matters for HomeKit bucketing; keep low->high progression
+UI_FAN_ORDER = ["auto", "quiet", "low", "medium", "high", "powerful"]
+
+
+# =============================================================================
+# Vane (air direction) mapping: Kumo Cloud API values <-> Comfort app UI labels
+# =============================================================================
+
+API_TO_UI_VANE = {
+    "auto": "auto",
+    "swing": "swing",
+    "vertical": "lowest",
+    "midvertical": "low",
+    "midpoint": "middle",
+    "midhorizontal": "high",
+    "horizontal": "highest",
+}
+UI_TO_API_VANE = {
+    "auto": "auto",
+    "swing": "swing",
+    "lowest": "vertical",
+    "low": "midvertical",
+    "middle": "midpoint",
+    "high": "midhorizontal",
+    "highest": "horizontal",
+}
+UI_VANE_ORDER = ["auto", "swing", "lowest", "low", "middle", "high", "highest"]
+
+
+# Debug logging follows HA's log level (no hardcoded flag needed).
+def _debug(msg: str, *args: Any) -> None:
+    """Log only when HA logger is set to DEBUG for this component."""
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        _LOGGER.debug(msg, *args)
+
+
+# =============================================================================
+# HVAC mode mappings
+# =============================================================================
+
 KUMO_TO_HVAC_MODE = {
     OPERATION_MODE_OFF: HVACMode.OFF,
     OPERATION_MODE_COOL: HVACMode.COOL,
@@ -46,20 +178,22 @@ KUMO_TO_HVAC_MODE = {
     OPERATION_MODE_DRY: HVACMode.DRY,
     OPERATION_MODE_VENT: HVACMode.FAN_ONLY,
     OPERATION_MODE_AUTO: HVACMode.HEAT_COOL,
+    OPERATION_MODE_AUTO_COOL: HVACMode.HEAT_COOL,
+    OPERATION_MODE_AUTO_HEAT: HVACMode.HEAT_COOL,
 }
 
-# Reverse mapping
-HVAC_TO_KUMO_MODE = {v: k for k, v in KUMO_TO_HVAC_MODE.items()}
+HVAC_TO_KUMO_MODE = {
+    HVACMode.OFF: OPERATION_MODE_OFF,
+    HVACMode.COOL: OPERATION_MODE_COOL,
+    HVACMode.HEAT: OPERATION_MODE_HEAT,
+    HVACMode.DRY: OPERATION_MODE_DRY,
+    HVACMode.FAN_ONLY: OPERATION_MODE_VENT,
+    HVACMode.HEAT_COOL: OPERATION_MODE_AUTO,
+}
 
-# Fan speed mappings
+# Legacy constants kept for reference
 KUMO_FAN_SPEEDS = [FAN_SPEED_AUTO, FAN_SPEED_LOW, FAN_SPEED_MEDIUM, FAN_SPEED_HIGH]
-
-# Air direction mappings
-KUMO_AIR_DIRECTIONS = [
-    AIR_DIRECTION_HORIZONTAL,
-    AIR_DIRECTION_VERTICAL,
-    AIR_DIRECTION_SWING,
-]
+KUMO_AIR_DIRECTIONS = [AIR_DIRECTION_HORIZONTAL, AIR_DIRECTION_VERTICAL, AIR_DIRECTION_SWING]
 
 
 async def async_setup_entry(
@@ -85,7 +219,7 @@ async def async_setup_entry(
 class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
     """Representation of a Kumo Cloud climate device."""
 
-    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
     _attr_has_entity_name = True
     _attr_name = None
 
@@ -117,11 +251,16 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
             # Check for vane/swing support
             if profile_data.get("hasVaneSwing", False):
                 features |= ClimateEntityFeature.SWING_MODE
-
             if profile_data.get("hasVaneDir", False):
                 features |= ClimateEntityFeature.SWING_MODE
 
+            # Check if device supports both heat and cool (for dual setpoint support)
+            if profile_data.get("hasModeHeat", False):
+                features |= ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+
         self._attr_supported_features = features
+
+    # ---- Device info --------------------------------------------------------
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -140,37 +279,81 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
             serial_number=device_data.get("serialNumber"),
         )
 
+    # ---- Temperature properties ---------------------------------------------
+
     @property
     def current_temperature(self) -> float | None:
-        """Return the current temperature."""
+        """Return the current temperature (converted to Fahrenheit)."""
         adapter = self.device.zone_data.get("adapter", {})
-        return adapter.get("roomTemp")
+        return _c_to_f(adapter.get("roomTemp"))
 
     @property
     def target_temperature(self) -> float | None:
-        """Return the target temperature."""
+        """Return the target temperature for single-setpoint modes."""
         adapter = self.device.zone_data.get("adapter", {})
         hvac_mode = self.hvac_mode
 
         if hvac_mode == HVACMode.COOL:
-            return adapter.get("spCool")
+            return _c_to_f(adapter.get("spCool"))
         elif hvac_mode == HVACMode.HEAT:
-            return adapter.get("spHeat")
-        elif hvac_mode == HVACMode.HEAT_COOL:
-            # For auto mode, could return either cool or heat setpoint
-            # Return the cool setpoint as default
-            return adapter.get("spCool") or adapter.get("spHeat")
+            return _c_to_f(adapter.get("spHeat"))
 
+        # HEAT_COOL uses target_temperature_high/low instead
         return None
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the upper bound temperature for heat/cool mode."""
+        if self.hvac_mode == HVACMode.HEAT_COOL:
+            adapter = self.device.zone_data.get("adapter", {})
+            device_data = self.device.device_data
+            return _c_to_f(device_data.get("spCool", adapter.get("spCool")))
+        return None
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the lower bound temperature for heat/cool mode."""
+        if self.hvac_mode == HVACMode.HEAT_COOL:
+            adapter = self.device.zone_data.get("adapter", {})
+            device_data = self.device.device_data
+            return _c_to_f(device_data.get("spHeat", adapter.get("spHeat")))
+        return None
+
+    @property
+    def min_temp(self) -> float:
+        """Return minimum temperature."""
+        profile = self.device.profile_data
+        if profile:
+            profile_data = profile[0] if isinstance(profile, list) else profile
+            min_setpoints = profile_data.get("minimumSetPoints", {})
+            min_c = min(min_setpoints.get("heat", 16), min_setpoints.get("cool", 16))
+            return _c_to_f(min_c)
+        return _c_to_f(16.0)
+
+    @property
+    def max_temp(self) -> float:
+        """Return maximum temperature."""
+        profile = self.device.profile_data
+        if profile:
+            profile_data = profile[0] if isinstance(profile, list) else profile
+            max_setpoints = profile_data.get("maximumSetPoints", {})
+            max_c = max(max_setpoints.get("heat", 30), max_setpoints.get("cool", 30))
+            return _c_to_f(max_c)
+        return _c_to_f(30.0)
+
+    @property
+    def target_temperature_step(self) -> float:
+        """Return the supported step of target temperature."""
+        return 1.0  # 1 F steps (maps to ~0.5 C steps internally)
+
+    # ---- HVAC mode ----------------------------------------------------------
 
     @property
     def hvac_mode(self) -> HVACMode:
         """Return current HVAC mode."""
-        # Check both adapter (zone) and device data for most current status
         adapter = self.device.zone_data.get("adapter", {})
         device_data = self.device.device_data
 
-        # Use device data if available (more current), otherwise use adapter data
         operation_mode = device_data.get(
             "operationMode", adapter.get("operationMode", OPERATION_MODE_OFF)
         )
@@ -191,112 +374,92 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
         if profile:
             profile_data = profile[0] if isinstance(profile, list) else profile
 
-            # Add modes based on device capabilities
             if profile_data.get("hasModeHeat", False):
                 modes.append(HVACMode.HEAT)
-
-            modes.append(HVACMode.COOL)  # All units should support cool
-
+            if profile_data.get("hasModeCool", False):
+                modes.append(HVACMode.COOL)
             if profile_data.get("hasModeDry", False):
                 modes.append(HVACMode.DRY)
-
-            if profile_data.get("hasModeVent", False):
+            if profile_data.get("hasModeFan", False):
                 modes.append(HVACMode.FAN_ONLY)
-
-            # Auto mode if device supports both heat and cool
-            if profile_data.get("hasModeHeat", False):
+            if profile_data.get("hasModeAuto", False):
                 modes.append(HVACMode.HEAT_COOL)
+        else:
+            modes.extend([HVACMode.HEAT, HVACMode.COOL])
 
         return modes
 
     @property
     def hvac_action(self) -> HVACAction | None:
-        """Return current HVAC action based on actual device status."""
-        hvac_mode = self.hvac_mode
-        if hvac_mode == HVACMode.OFF:
-            return HVACAction.OFF
-
-        # Check both adapter (zone) and device data for most current status
-        adapter = self.device.zone_data.get("adapter", {})
+        """Return the current running HVAC operation."""
         device_data = self.device.device_data
+        adapter = self.device.zone_data.get("adapter", {})
 
-        # Use device data if available (more current), otherwise use adapter data
-        power = device_data.get("power", adapter.get("power", 0))
         operation_mode = device_data.get(
             "operationMode", adapter.get("operationMode", OPERATION_MODE_OFF)
         )
+        power = device_data.get("power", adapter.get("power", 0))
 
-        if power == 0:
+        if operation_mode == OPERATION_MODE_OFF or power == 0:
             return HVACAction.OFF
 
-        # If device is on and has a valid operation mode, show it as active
-        if operation_mode == OPERATION_MODE_HEAT:
-            # For heating mode, show as heating if power is on
-            return HVACAction.HEATING
-        elif operation_mode == OPERATION_MODE_COOL:
-            # For cooling mode, show as cooling if power is on
+        if operation_mode == OPERATION_MODE_COOL:
             return HVACAction.COOLING
+        elif operation_mode == OPERATION_MODE_HEAT:
+            return HVACAction.HEATING
         elif operation_mode == OPERATION_MODE_DRY:
             return HVACAction.DRYING
         elif operation_mode == OPERATION_MODE_VENT:
             return HVACAction.FAN
-        elif operation_mode == OPERATION_MODE_AUTO:
-            # For auto mode, determine action based on current vs target temperature
+        elif operation_mode in (OPERATION_MODE_AUTO, OPERATION_MODE_AUTO_COOL, OPERATION_MODE_AUTO_HEAT):
+            if operation_mode == OPERATION_MODE_AUTO_COOL:
+                return HVACAction.COOLING
+            elif operation_mode == OPERATION_MODE_AUTO_HEAT:
+                return HVACAction.HEATING
+
+            # Generic auto: infer from temperature difference
             current_temp = self.current_temperature
-            target_temp = self.target_temperature
+            target_temp = self.target_temperature_high or self.target_temperature
 
             if current_temp is not None and target_temp is not None:
                 temp_diff = current_temp - target_temp
-                if temp_diff > 1.0:  # More than 1 degree above target
+                if temp_diff > 1.0:
                     return HVACAction.COOLING
-                elif temp_diff < -1.0:  # More than 1 degree below target
+                elif temp_diff < -1.0:
                     return HVACAction.HEATING
 
-            # Default to idle for auto mode if we can't determine
             return HVACAction.IDLE
 
-        # If power is on but we can't determine the action, show as idle
         return HVACAction.IDLE
+
+    # ---- Fan mode -----------------------------------------------------------
 
     @property
     def fan_mode(self) -> str | None:
-        """Return current fan mode."""
-        # Check device data first, then adapter data
+        """Return current fan mode (canonical lowercase UI label)."""
         device_data = self.device.device_data
         adapter = self.device.zone_data.get("adapter", {})
-        return device_data.get("fanSpeed", adapter.get("fanSpeed"))
+        fan_speed = device_data.get("fanSpeed", adapter.get("fanSpeed"))
+        _debug("API returned fanSpeed for %s: %s", self.device.device_serial, fan_speed)
+        ui_label = API_TO_UI_FAN.get(fan_speed, fan_speed)
+        _debug("HA presenting fan mode for %s as: %s", self.device.device_serial, ui_label)
+        return ui_label
 
     @property
-    def fan_modes(self) -> list[str] | None:
+    def fan_modes(self) -> list[str]:
         """Return the list of available fan modes."""
-        profile = self.device.profile_data
-        if not profile:
-            return None
+        return UI_FAN_ORDER.copy()
 
-        profile_data = profile[0] if isinstance(profile, list) else profile
-        num_fan_speeds = profile_data.get("numberOfFanSpeeds", 0)
-
-        if num_fan_speeds == 0:
-            return None
-
-        # Return fan modes based on number of speeds supported
-        modes = [FAN_SPEED_AUTO]
-        if num_fan_speeds >= 1:
-            modes.append(FAN_SPEED_LOW)
-        if num_fan_speeds >= 2:
-            modes.append(FAN_SPEED_MEDIUM)
-        if num_fan_speeds >= 3:
-            modes.append(FAN_SPEED_HIGH)
-
-        return modes
+    # ---- Swing (vane) mode --------------------------------------------------
 
     @property
     def swing_mode(self) -> str | None:
-        """Return current swing mode."""
-        # Check device data first, then adapter data
+        """Return current vane position (canonical lowercase UI label)."""
         device_data = self.device.device_data
         adapter = self.device.zone_data.get("adapter", {})
-        return device_data.get("airDirection", adapter.get("airDirection"))
+        swing = device_data.get("airDirection", adapter.get("airDirection"))
+        _debug("API returned airDirection for %s: %s", self.device.device_serial, swing)
+        return API_TO_UI_VANE.get(swing, swing)
 
     @property
     def swing_modes(self) -> list[str] | None:
@@ -306,52 +469,55 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
             return None
 
         profile_data = profile[0] if isinstance(profile, list) else profile
+        if not (profile_data.get("hasVaneDir", False) or profile_data.get("hasVaneSwing", False)):
+            return None
 
-        modes = []
-        if profile_data.get("hasVaneDir", False) or profile_data.get(
-            "hasVaneSwing", False
-        ):
-            modes.extend(KUMO_AIR_DIRECTIONS)
+        return UI_VANE_ORDER.copy()
 
-        return modes if modes else None
+    # ---- Misc properties ----------------------------------------------------
 
     @property
-    def min_temp(self) -> float:
-        """Return minimum temperature."""
-        profile = self.device.profile_data
-        if profile:
-            profile_data = profile[0] if isinstance(profile, list) else profile
-            min_setpoints = profile_data.get("minimumSetPoints", {})
-            # Return the minimum of heat and cool setpoints
-            return min(min_setpoints.get("heat", 16), min_setpoints.get("cool", 16))
-        return 16.0
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the optional state attributes."""
+        attributes = super().extra_state_attributes or {}
 
-    @property
-    def max_temp(self) -> float:
-        """Return maximum temperature."""
-        profile = self.device.profile_data
-        if profile:
-            profile_data = profile[0] if isinstance(profile, list) else profile
-            max_setpoints = profile_data.get("maximumSetPoints", {})
-            # Return the maximum of heat and cool setpoints
-            return max(max_setpoints.get("heat", 30), max_setpoints.get("cool", 30))
-        return 30.0
+        adapter = self.device.zone_data.get("adapter", {})
+        device_data = self.device.device_data
+        humidity = device_data.get("humidity", adapter.get("humidity"))
+        if humidity is not None:
+            attributes["humidity"] = humidity
 
-    @property
-    def target_temperature_step(self) -> float:
-        """Return the supported step of target temperature."""
-        return 0.5  # Kumo Cloud typically supports 0.5 degree steps
+        return attributes
 
     @property
     def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.device.available and self.coordinator.last_update_success
+        """Return True if entity is available.
+
+        Keep entity available when we have data even if the last poll failed.
+        This prevents automations from triggering spuriously when the entity
+        flickers between available/unavailable due to transient API errors.
+        """
+        has_data = (
+            self.device.zone_data
+            and self.device.device_data
+            and self.coordinator.data is not None
+        )
+        return has_data and self.device.available
+
+    # ---- Commands -----------------------------------------------------------
 
     async def _send_command_and_refresh(self, commands: dict[str, Any]) -> None:
-        """Send command and ensure fresh status update."""
+        """Send command, cache it to prevent bounce, and refresh."""
+        _debug("HA sending command to %s: %s", self.device.device_serial, commands)
+
+        # Cache the command first so UI updates immediately
+        self.device.cache_commands(commands)
+        self.async_write_ha_state()
+
+        # Send the command and refresh the device
         await self.device.send_command(commands)
-        # The device.send_command method now handles refreshing the device status
-        # Also trigger a state update for this entity to reflect changes immediately
+
+        # Write state again after refresh
         self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -367,7 +533,6 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
                 adapter = self.device.zone_data.get("adapter", {})
                 device_data = self.device.device_data
 
-                # Use device data if available, otherwise adapter data
                 sp_cool = device_data.get("spCool", adapter.get("spCool"))
                 sp_heat = device_data.get("spHeat", adapter.get("spHeat"))
 
@@ -380,62 +545,86 @@ class KumoCloudClimate(CoordinatorEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        target_temp = kwargs.get(ATTR_TEMPERATURE)
-        if target_temp is None:
-            return
-
-        hvac_mode = self.hvac_mode
-        commands = {}
-
         adapter = self.device.zone_data.get("adapter", {})
         device_data = self.device.device_data
+        commands: dict[str, Any] = {}
+
+        # Range set (preferred for HEAT_COOL / auto)
+        low_f = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        high_f = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+
+        if low_f is not None or high_f is not None:
+            current_low_c = device_data.get("spHeat", adapter.get("spHeat"))
+            current_high_c = device_data.get("spCool", adapter.get("spCool"))
+
+            if low_f is not None:
+                commands["spHeat"] = _f_to_c(low_f)
+            elif current_low_c is not None:
+                commands["spHeat"] = current_low_c
+
+            if high_f is not None:
+                commands["spCool"] = _f_to_c(high_f)
+            elif current_high_c is not None:
+                commands["spCool"] = current_high_c
+
+            if commands:
+                await self._send_command_and_refresh(commands)
+            return
+
+        # Single setpoint (heat/cool modes)
+        target_temp_f = kwargs.get(ATTR_TEMPERATURE)
+        if target_temp_f is None:
+            return
+
+        target_temp_c = _f_to_c(target_temp_f)
+        hvac_mode = self.hvac_mode
 
         if hvac_mode == HVACMode.COOL:
-            commands["spCool"] = target_temp
-            # Maintain heat setpoint
+            commands["spCool"] = target_temp_c
             sp_heat = device_data.get("spHeat", adapter.get("spHeat"))
             if sp_heat is not None:
                 commands["spHeat"] = sp_heat
+
         elif hvac_mode == HVACMode.HEAT:
-            commands["spHeat"] = target_temp
-            # Maintain cool setpoint
+            commands["spHeat"] = target_temp_c
             sp_cool = device_data.get("spCool", adapter.get("spCool"))
             if sp_cool is not None:
                 commands["spCool"] = sp_cool
+
         elif hvac_mode == HVACMode.HEAT_COOL:
-            # For auto mode, set both setpoints based on current temperature
-            commands["spCool"] = target_temp
-            commands["spHeat"] = target_temp - 2  # 2 degree hysteresis
+            # Single setpoint in auto mode: set both with hysteresis
+            commands["spCool"] = target_temp_c
+            commands["spHeat"] = target_temp_c - 1.0  # ~2 F hysteresis
 
         if commands:
             await self._send_command_and_refresh(commands)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
-        """Set new target fan mode."""
-        await self._send_command_and_refresh({"fanSpeed": fan_mode})
+        """Set new target fan mode (accepts UI label, sends API value)."""
+        api_value = UI_TO_API_FAN.get(fan_mode.lower(), fan_mode)
+        _debug("Setting fan mode: UI '%s' -> API '%s'", fan_mode, api_value)
+        await self._send_command_and_refresh({"fanSpeed": api_value})
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
-        """Set new target swing mode."""
-        await self._send_command_and_refresh({"airDirection": swing_mode})
+        """Set vane position (accepts UI label, sends API value)."""
+        api_value = UI_TO_API_VANE.get(swing_mode.lower(), swing_mode)
+        _debug("Setting swing mode: UI '%s' -> API '%s'", swing_mode, api_value)
+        await self._send_command_and_refresh({"airDirection": api_value})
 
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        # Turn on with the last used mode, or cool mode if no previous mode
         adapter = self.device.zone_data.get("adapter", {})
         device_data = self.device.device_data
 
-        # Use device data if available, otherwise adapter data
         operation_mode = device_data.get(
             "operationMode", adapter.get("operationMode", OPERATION_MODE_COOL)
         )
 
-        # If the operation mode is "off", default to cool
         if operation_mode == OPERATION_MODE_OFF:
             operation_mode = OPERATION_MODE_COOL
 
         commands = {"operationMode": operation_mode}
 
-        # Include setpoints
         sp_cool = device_data.get("spCool", adapter.get("spCool"))
         sp_heat = device_data.get("spHeat", adapter.get("spHeat"))
 

--- a/custom_components/kumo_cloud/const.py
+++ b/custom_components/kumo_cloud/const.py
@@ -8,7 +8,7 @@ CONF_SITE_ID = "site_id"
 # API constants
 API_BASE_URL = "https://app-prod.kumocloud.com"
 API_VERSION = "v3"
-API_APP_VERSION = "3.0.9"
+API_APP_VERSION = "3.2.4"
 
 # Token refresh constants
 TOKEN_REFRESH_INTERVAL = 1200  # 20 minutes in seconds
@@ -26,14 +26,16 @@ OPERATION_MODE_HEAT = "heat"
 OPERATION_MODE_DRY = "dry"
 OPERATION_MODE_VENT = "vent"
 OPERATION_MODE_AUTO = "auto"
+OPERATION_MODE_AUTO_COOL = "autoCool"
+OPERATION_MODE_AUTO_HEAT = "autoHeat"
 
-# Fan speeds
+# Fan speeds (raw API values -- see climate.py for UI label mapping)
 FAN_SPEED_AUTO = "auto"
 FAN_SPEED_LOW = "low"
 FAN_SPEED_MEDIUM = "medium"
 FAN_SPEED_HIGH = "high"
 
-# Air direction
+# Air direction (raw API values -- see climate.py for UI label mapping)
 AIR_DIRECTION_HORIZONTAL = "horizontal"
 AIR_DIRECTION_VERTICAL = "vertical"
 AIR_DIRECTION_SWING = "swing"

--- a/custom_components/kumo_cloud/coordinator.py
+++ b/custom_components/kumo_cloud/coordinator.py
@@ -1,0 +1,339 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any
+import asyncio
+import logging
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.core import HomeAssistant
+
+from .api import KumoCloudAPI, KumoCloudAuthError, KumoCloudConnectionError
+from .const import DOMAIN, DEFAULT_SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+class KumoCloudDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Kumo Cloud data."""
+
+    def __init__(self, hass: HomeAssistant, api: KumoCloudAPI, site_id: str) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        )
+        self.api = api
+        self.site_id = site_id
+        self.zones: list[dict[str, Any]] = []
+        self.devices: dict[str, dict[str, Any]] = {}
+        self.device_profiles: dict[str, list[dict[str, Any]]] = {}
+        self.wireless_sensors: dict[str, dict[str, Any]] = {}
+        self.device_statuses: dict[str, dict[str, Any]] = {}
+        self.zone_notifications: dict[str, dict[str, Any]] = {}
+
+        # Instance variable to store cached commands
+        self.cached_commands: dict[tuple[str, str], tuple[str, Any]] = {}
+
+    def _process_pending_commands(self, device_serial: str, device_detail: dict[str, Any]) -> None:
+        """Process cached commands and cull outdated commands for a device."""
+        # Check if the device already exists and the updatedAt matches
+        if device_serial in self.devices and "updatedAt" in device_detail:
+            self.cull_cached_commands(device_serial, device_detail.get("updatedAt"))
+
+        # Reapply cached commands to the device details
+        for (cached_device_serial, command), (_, command_value) in self.cached_commands.items():
+            if cached_device_serial == device_serial:
+                device_detail[command] = command_value
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from Kumo Cloud."""
+        try:
+            # Get zones for the site
+            zones = await self.api.get_zones(self.site_id)
+
+            # Get device details for each zone
+            devices = {}
+            device_profiles = {}
+            wireless_sensors = {}
+            device_statuses = {}
+            zone_notifications = {}
+
+            for zone in zones:
+                if "adapter" in zone and zone["adapter"]:
+                    device_serial = zone["adapter"]["deviceSerial"]
+                    zone_id = zone["id"]
+                    has_sensor = zone["adapter"].get("hasSensor", False)
+
+                    # Build task list - fetch everything in parallel
+                    task_keys = ["detail", "profile", "status", "notifications"]
+                    tasks = [
+                        self.api.get_device_details(device_serial),
+                        self.api.get_device_profile(device_serial),
+                        self.api.get_device_status(device_serial),
+                        self.api.get_zone_notification_preferences(zone_id),
+                    ]
+                    # Also fetch wireless sensor data if the zone has one
+                    if has_sensor:
+                        task_keys.append("sensor")
+                        tasks.append(self.api.get_wireless_sensor(device_serial))
+
+                    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                    # Process results by key
+                    result_map = {}
+                    for key, result in zip(task_keys, results):
+                        if isinstance(result, Exception):
+                            _LOGGER.debug("Failed to fetch %s for %s: %s", key, device_serial, result)
+                            result_map[key] = None
+                        else:
+                            result_map[key] = result
+
+                    device_detail = result_map.get("detail") or {}
+
+                    # Process pending commands for the device
+                    self._process_pending_commands(device_serial, device_detail)
+
+                    devices[device_serial] = device_detail
+                    device_profiles[device_serial] = result_map.get("profile") or []
+
+                    if result_map.get("status"):
+                        device_statuses[device_serial] = result_map["status"]
+
+                    if result_map.get("notifications"):
+                        zone_notifications[zone_id] = result_map["notifications"]
+
+                    if has_sensor and result_map.get("sensor"):
+                        wireless_sensors[device_serial] = result_map["sensor"]
+
+            # Store the data for access by entities
+            self.zones = zones
+            self.devices = devices
+            self.device_profiles = device_profiles
+            self.wireless_sensors = wireless_sensors
+            self.device_statuses = device_statuses
+            self.zone_notifications = zone_notifications
+
+            return {
+                "zones": zones,
+                "devices": devices,
+                "device_profiles": device_profiles,
+                "wireless_sensors": wireless_sensors,
+                "device_statuses": device_statuses,
+                "zone_notifications": zone_notifications,
+            }
+
+        except KumoCloudAuthError as err:
+            # Try to refresh token once
+            try:
+                await self.api.refresh_access_token()
+                # Retry the request
+                return await self._async_update_data()
+            except KumoCloudAuthError as refresh_err:
+                raise UpdateFailed(
+                    f"Authentication failed: {refresh_err}"
+                ) from refresh_err
+        except KumoCloudConnectionError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+        except Exception as err:
+            raise UpdateFailed(f"Unexpected error: {err}") from err
+
+    async def async_refresh_device(self, device_serial: str) -> None:
+        """Refresh a specific device's data immediately."""
+        try:
+            # Get fresh device details
+            device_detail = await self.api.get_device_details(device_serial)
+
+            # Process pending commands for the device
+            self._process_pending_commands(device_serial, device_detail)
+
+            # Update the cached device data
+            self.devices[device_serial] = device_detail
+
+            # Also update the zone data if it contains the same info
+            for zone in self.zones:
+                if "adapter" in zone and zone["adapter"]:
+                    if zone["adapter"]["deviceSerial"] == device_serial:
+                        # Update adapter data with fresh device data
+                        zone["adapter"].update(
+                            {
+                                "roomTemp": device_detail.get("roomTemp"),
+                                "operationMode": device_detail.get("operationMode"),
+                                "power": device_detail.get("power"),
+                                "fanSpeed": device_detail.get("fanSpeed"),
+                                "airDirection": device_detail.get("airDirection"),
+                                "spCool": device_detail.get("spCool"),
+                                "spHeat": device_detail.get("spHeat"),
+                                "humidity": device_detail.get("humidity"),
+                            }
+                        )
+                        break
+
+            # Update the coordinator's data dict
+            self.data = {
+                "zones": self.zones,
+                "devices": self.devices,
+                "device_profiles": self.device_profiles,
+                "wireless_sensors": self.wireless_sensors,
+                "device_statuses": self.device_statuses,
+                "zone_notifications": self.zone_notifications,
+            }
+
+            # Notify all listeners that data has been updated
+            self.async_update_listeners()
+
+            _LOGGER.debug("Refreshed device %s data", device_serial)
+
+        except Exception as err:
+            _LOGGER.warning("Failed to refresh device %s: %s", device_serial, err)
+
+    def cache_command(self, device_serial: str, command: str, value: Any) -> None:
+        """Cache a command with its value and timestamp."""
+        current_time = datetime.now(timezone.utc).isoformat()
+        self.cached_commands[(device_serial, command)] = (current_time, value)
+        _LOGGER.debug("Cached command in device data: %s at %s", command, current_time)
+
+    def cull_cached_commands(self, device_serial: str, date: str) -> None:
+        """Remove cached commands for a device where the date is on or after the item's timestamp."""
+        to_remove = []
+        input_date = datetime.fromisoformat(date)
+
+        for key, value in self.cached_commands.items():
+            cached_device_serial, command = key
+            cached_date, _ = value
+            cached_date_obj = datetime.fromisoformat(cached_date)
+
+            # Check if the device_serial matches and the input date is on or after the cached date
+            if cached_device_serial == device_serial and input_date >= cached_date_obj:
+                to_remove.append(key)
+            else:
+                # Log details if the condition fails
+                _LOGGER.debug(
+                    "Skipping cached command: cached_device_serial=%s, device_serial=%s, "
+                    "input_date=%s, cached_date_obj=%s, date=%s, cached_date=%s",
+                    cached_device_serial,
+                    device_serial,
+                    input_date,
+                    cached_date_obj,
+                    date,
+                    cached_date,
+                )
+
+        # Remove the matching keys
+        for key in to_remove:
+            del self.cached_commands[key]
+
+        # Log the culled and remaining commands
+        remaining_count = len(self.cached_commands)
+        _LOGGER.debug(
+            "Culled %d cached commands for device %s on or after %s. Remaining cached commands: %d",
+            len(to_remove), device_serial, date, remaining_count
+        )
+
+class KumoCloudDevice:
+    """Representation of a Kumo Cloud device."""
+
+    def __init__(
+        self,
+        coordinator: KumoCloudDataUpdateCoordinator,
+        zone_id: str,
+        device_serial: str,
+    ) -> None:
+        """Initialize the device."""
+        self.coordinator = coordinator
+        self.zone_id = zone_id
+        self.device_serial = device_serial
+        self._zone_data: dict[str, Any] | None = None
+        self._device_data: dict[str, Any] | None = None
+        self._profile_data: list[dict[str, Any]] | None = None
+
+    @property
+    def zone_data(self) -> dict[str, Any]:
+        """Get the zone data."""
+        # Always get fresh data from coordinator
+        for zone in self.coordinator.zones:
+            if zone["id"] == self.zone_id:
+                return zone
+        return {}
+
+    @property
+    def device_data(self) -> dict[str, Any]:
+        """Get the device data."""
+        # Always get fresh data from coordinator
+        return self.coordinator.devices.get(self.device_serial, {})
+
+    @property
+    def profile_data(self) -> list[dict[str, Any]]:
+        """Get the device profile data."""
+        # Always get fresh data from coordinator
+        return self.coordinator.device_profiles.get(self.device_serial, [])
+
+    @property
+    def has_wireless_sensor(self) -> bool:
+        """Return True if this device has a wireless sensor attached."""
+        zone = self.zone_data
+        adapter = zone.get("adapter", {})
+        return adapter.get("hasSensor", False)
+
+    @property
+    def wireless_sensor_data(self) -> dict[str, Any] | None:
+        """Get the wireless sensor data (battery, temp, humidity, rssi)."""
+        return self.coordinator.wireless_sensors.get(self.device_serial)
+
+    @property
+    def device_status_data(self) -> dict[str, Any] | None:
+        """Get device status data (firmware, WiFi signal, router info)."""
+        return self.coordinator.device_statuses.get(self.device_serial)
+
+    @property
+    def zone_notification_data(self) -> dict[str, Any] | None:
+        """Get zone notification preferences (filter reminders, alert settings)."""
+        return self.coordinator.zone_notifications.get(self.zone_id)
+
+    @property
+    def available(self) -> bool:
+        """Return True if device is available."""
+        adapter = self.zone_data.get("adapter", {})
+        device_data = self.device_data
+
+        # Check both adapter and device data for connection status
+        adapter_connected = adapter.get("connected", False)
+        device_connected = device_data.get("connected", adapter_connected)
+
+        return device_connected
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.zone_data.get("name", f"Zone {self.zone_id}")
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID for the device."""
+        return f"{self.device_serial}_{self.zone_id}"
+
+    async def send_command(self, commands: dict[str, Any]) -> None:
+        """Send a command to the device and refresh status."""
+        try:
+            response = await self.coordinator.api.send_command(self.device_serial, commands)
+            _LOGGER.debug("Sent command to device %s: %s, Response: %s", self.device_serial, commands, response)
+
+            # Wait a moment for the command to be processed
+            await asyncio.sleep(1)
+
+            # Refresh this specific device's data immediately
+            await self.coordinator.async_refresh_device(self.device_serial)
+
+        except Exception as err:
+            _LOGGER.error(
+                "Failed to send command to device %s: %s", self.device_serial, err
+            )
+            raise
+
+    def cache_command(self, command: str, value: Any) -> None:
+        """Cache a command with its value and timestamp in the coordinator."""
+        self.coordinator.cache_command(self.device_serial, command, value)
+
+    def cache_commands(self, commands: dict[str, Any]) -> None:
+        """Cache multiple commands with their values and timestamps in the coordinator."""
+        for command, value in commands.items():
+            self.cache_command(command, value)

--- a/custom_components/kumo_cloud/manifest.json
+++ b/custom_components/kumo_cloud/manifest.json
@@ -1,12 +1,12 @@
 {
     "domain": "kumo_cloud",
     "name": "Mitsubishi Comfort",
-    "codeowners": ["@jjustinwilson"],
+    "codeowners": ["@JoeQuantum"],
     "config_flow": true,
-    "documentation": "https://github.com/jjustinwilson/comfort_HA/",
-    "issue_tracker": "https://github.com/jjustinwilson/comfort_HA/issues",
+    "documentation": "https://github.com/JoeQuantum/comfort_HA/",
+    "issue_tracker": "https://github.com/JoeQuantum/comfort_HA/issues",
     "iot_class": "cloud_polling",
     "loggers": ["kumo_cloud"],
     "requirements": ["aiohttp>=3.8.0"],
-    "version": "1.0.0"
-  }
+    "version": "1.1.0"
+}

--- a/custom_components/kumo_cloud/sensor.py
+++ b/custom_components/kumo_cloud/sensor.py
@@ -1,0 +1,355 @@
+"""Platform for Kumo Cloud sensors.
+
+Provides standalone sensor entities for each Mitsubishi zone:
+- Temperature (from indoor unit's built-in thermistor)
+- Humidity (from indoor unit)
+- WiFi Adapter Firmware Version (diagnostic, from /status)
+- WiFi Signal Strength (diagnostic, routerRssi from /status)
+- Filter Reminder (diagnostic, from /notification-preferences)
+
+For zones with a wireless sensor (PAC-USWHS003-TH-1) attached:
+- Wireless Sensor Battery (%)
+- Wireless Sensor Signal Strength (RSSI dBm)
+- Wireless Sensor Temperature (from the remote sensor itself)
+- Wireless Sensor Humidity (from the remote sensor itself)
+
+API endpoints discovered via Proxyman traffic capture of the Comfort app:
+- /v3/devices/{serial}/sensor  (wireless sensor data)
+- /v3/devices/{serial}/status  (firmware, WiFi signal, router info)
+- /v3/zones/{zoneId}/notification-preferences  (filter reminders)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    EntityCategory,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import KumoCloudDataUpdateCoordinator, KumoCloudDevice
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Kumo Cloud sensor devices."""
+    coordinator: KumoCloudDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+    for zone in coordinator.zones:
+        if "adapter" in zone and zone["adapter"]:
+            device_serial = zone["adapter"]["deviceSerial"]
+            zone_id = zone["id"]
+            has_sensor = zone["adapter"].get("hasSensor", False)
+
+            device = KumoCloudDevice(coordinator, zone_id, device_serial)
+
+            # Indoor unit sensors (always available)
+            entities.append(KumoCloudTemperatureSensor(coordinator, device))
+            entities.append(KumoCloudHumiditySensor(coordinator, device))
+
+            # Diagnostic sensors from /status endpoint (always available)
+            entities.append(KumoCloudFirmwareSensor(coordinator, device))
+            entities.append(KumoCloudWiFiSignalSensor(coordinator, device))
+            entities.append(KumoCloudFilterReminderSensor(coordinator, device))
+
+            # Wireless sensor entities (only if hasSensor is true)
+            if has_sensor:
+                entities.append(KumoCloudWirelessBatterySensor(coordinator, device))
+                entities.append(KumoCloudWirelessSignalSensor(coordinator, device))
+                entities.append(KumoCloudWirelessTemperatureSensor(coordinator, device))
+                entities.append(KumoCloudWirelessHumiditySensor(coordinator, device))
+
+    async_add_entities(entities)
+
+
+def _device_info(device: KumoCloudDevice) -> DeviceInfo:
+    """Return standard device info for all sensors."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, device.device_serial)},
+        name=device.zone_data.get("name", "Kumo Cloud Device"),
+        manufacturer="Mitsubishi Electric",
+    )
+
+
+# =============================================================================
+# Indoor unit sensors
+# =============================================================================
+
+class KumoCloudTemperatureSensor(CoordinatorEntity, SensorEntity):
+    """Temperature from the indoor unit's built-in thermistor."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Temperature"
+        self._attr_unique_id = f"{device.device_serial}_temperature"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        adapter = self.device.zone_data.get("adapter", {})
+        return adapter.get("roomTemp")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudHumiditySensor(CoordinatorEntity, SensorEntity):
+    """Humidity from the indoor unit."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Humidity"
+        self._attr_unique_id = f"{device.device_serial}_humidity"
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_device_class = SensorDeviceClass.HUMIDITY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        adapter = self.device.zone_data.get("adapter", {})
+        device_data = self.device.device_data
+        return device_data.get("humidity", adapter.get("humidity"))
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+# =============================================================================
+# Diagnostic sensors from /devices/{serial}/status
+# =============================================================================
+
+class KumoCloudFirmwareSensor(CoordinatorEntity, SensorEntity):
+    """WiFi adapter firmware version."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Firmware"
+        self._attr_unique_id = f"{device.device_serial}_firmware"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:chip"
+
+    @property
+    def native_value(self) -> str | None:
+        status = self.device.device_status_data
+        if status is None:
+            return None
+        return status.get("firmwareVersion")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudWiFiSignalSensor(CoordinatorEntity, SensorEntity):
+    """WiFi adapter signal strength to the router."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} WiFi Signal"
+        self._attr_unique_id = f"{device.device_serial}_wifi_rssi"
+        self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> int | None:
+        status = self.device.device_status_data
+        if status is None:
+            return None
+        return status.get("routerRssi")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Include router SSID as an attribute."""
+        status = self.device.device_status_data
+        if status and status.get("routerSsid"):
+            return {"router_ssid": status["routerSsid"]}
+        return {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudFilterReminderSensor(CoordinatorEntity, SensorEntity):
+    """Last filter dirty reminder date."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Filter Reminder"
+        self._attr_unique_id = f"{device.device_serial}_filter_reminder"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:air-filter"
+
+    @property
+    def native_value(self) -> datetime | None:
+        notifications = self.device.zone_notification_data
+        if notifications is None:
+            return None
+        last_sent = notifications.get("filterDirtyReminderLastSent")
+        if last_sent:
+            try:
+                return datetime.fromisoformat(last_sent.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                return None
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Include reminder interval as an attribute."""
+        notifications = self.device.zone_notification_data
+        if notifications:
+            attrs = {}
+            interval = notifications.get("filterDirtyReminderInterval")
+            if interval is not None:
+                attrs["reminder_interval_days"] = interval
+            enabled = notifications.get("filterDirty")
+            if enabled is not None:
+                attrs["reminders_enabled"] = enabled
+            return attrs
+        return {}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+# =============================================================================
+# Wireless sensor entities (PAC-USWHS003-TH-1)
+# =============================================================================
+
+class KumoCloudWirelessBatterySensor(CoordinatorEntity, SensorEntity):
+    """Battery level of the wireless temperature/humidity sensor."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Wireless Sensor Battery"
+        self._attr_unique_id = f"{device.device_serial}_wireless_battery"
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_device_class = SensorDeviceClass.BATTERY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> int | None:
+        sensor_data = self.device.wireless_sensor_data
+        if sensor_data is None:
+            return None
+        return sensor_data.get("battery")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudWirelessSignalSensor(CoordinatorEntity, SensorEntity):
+    """Signal strength (RSSI) of the wireless sensor to the WiFi adapter."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Wireless Sensor Signal"
+        self._attr_unique_id = f"{device.device_serial}_wireless_rssi"
+        self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+        self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> int | None:
+        sensor_data = self.device.wireless_sensor_data
+        if sensor_data is None:
+            return None
+        return sensor_data.get("rssi")
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudWirelessTemperatureSensor(CoordinatorEntity, SensorEntity):
+    """Temperature reading from the wireless sensor itself."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Wireless Sensor Temperature"
+        self._attr_unique_id = f"{device.device_serial}_wireless_temperature"
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        sensor_data = self.device.wireless_sensor_data
+        if sensor_data is None:
+            return None
+        temp = sensor_data.get("temperature")
+        if temp is not None:
+            return round(temp, 1)
+        return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)
+
+
+class KumoCloudWirelessHumiditySensor(CoordinatorEntity, SensorEntity):
+    """Humidity reading from the wireless sensor itself."""
+
+    def __init__(self, coordinator: KumoCloudDataUpdateCoordinator, device: KumoCloudDevice) -> None:
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_name = f"{device.zone_data.get('name', 'Kumo Cloud')} Wireless Sensor Humidity"
+        self._attr_unique_id = f"{device.device_serial}_wireless_humidity"
+        self._attr_native_unit_of_measurement = PERCENTAGE
+        self._attr_device_class = SensorDeviceClass.HUMIDITY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> float | None:
+        sensor_data = self.device.wireless_sensor_data
+        if sensor_data is None:
+            return None
+        humidity = sensor_data.get("humidity")
+        if humidity is not None:
+            return round(humidity, 1)
+        return None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return _device_info(self.device)

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,4 @@
 {
-  "name": "Mitsubishi Comfort",
-  "hacs": "1.6.0",
-  "domains": ["climate"],
-  "iot_class": "Cloud Polling",
-  "homeassistant": "2023.1.0"
-} 
+    "name": "Mitsubishi Comfort",
+    "render_readme": true
+}

--- a/info.md
+++ b/info.md
@@ -9,6 +9,7 @@ Control your Mitsubishi Electric climate control systems through the Kumo Cloud 
 - Multi-zone support
 - Automatic authentication handling
 - Device capability detection
+- Auto Heat/Cool boundary mode support
 
 ## Setup
 


### PR DESCRIPTION
This PR merges improvements from multiple forks and adds new features discovered through Comfort app API traffic analysis.

## Merged from existing forks
- **ekiczek**: Mitsubishi F/C temperature lookup tables (fixes ~1°F drift at certain setpoints due to proprietary conversion table)
- **smack000**: Command caching/anti-bounce, coordinator refactor, standalone temp/humidity sensors, auto heat/cool modes
- **tw3rp**: Dual setpoints (TARGET_TEMPERATURE_RANGE), improved availability handling, API rate limiting with exponential backoff

## New features
- **Fan speed mapping**: UI labels match Comfort app (auto/quiet/low/medium/high/powerful) with internal API translation
- **Vane/air direction mapping**: UI labels match Comfort app (auto/swing/lowest/low/middle/high/highest)
- **Wireless sensor support** (PAC-USWHS003-TH-1): Battery level, signal strength, temperature, and humidity via newly discovered `/v3/devices/{serial}/sensor` endpoint
- **Diagnostic sensors**: WiFi adapter firmware version and signal strength via `/v3/devices/{serial}/status`, filter maintenance reminders via `/v3/zones/{id}/notification-preferences`
- **Updated API app version** from 3.0.9 to 3.2.4

## New API endpoints discovered
These were found by intercepting Comfort app (v3.2.4) HTTP traffic:
- `GET /v3/devices/{serial}/sensor` - wireless sensor battery, rssi, temp, humidity
- `GET /v3/devices/{serial}/status` - firmware version, router SSID/RSSI
- `GET /v3/zones/{id}/notification-preferences` - filter reminders

## Entity summary per zone
| Entity | Source | Always |
|--------|--------|--------|
| Climate | /devices/{serial} | Yes |
| Temperature | Zone adapter roomTemp | Yes |
| Humidity | Device humidity | Yes |
| Firmware | /devices/{serial}/status | Yes |
| WiFi Signal | /devices/{serial}/status | Yes |
| Filter Reminder | /zones/{id}/notification-preferences | Yes |
| Wireless Battery | /devices/{serial}/sensor | hasSensor only |
| Wireless Signal | /devices/{serial}/sensor | hasSensor only |
| Wireless Temp | /devices/{serial}/sensor | hasSensor only |
| Wireless Humidity | /devices/{serial}/sensor | hasSensor only |

Tested on HA Core 2026.2.3, HAOS 17.1, with two Mitsubishi zones and one PAC-USWHS003-TH-1 wireless sensor.