### PR TITLE
Fix auth error swallowed as connection error in login()

### DIFF
--- a/custom_components/kumo_cloud/api.py
+++ b/custom_components/kumo_cloud/api.py
@@ -89,6 +89,8 @@ class KumoCloudAPI:
             if err.status == 403:
                 raise KumoCloudAuthError("Invalid credentials") from err
             raise KumoCloudConnectionError(f"HTTP error: {err.status}") from err
+        except KumoCloudError:
+            raise
         except Exception as err:
             raise KumoCloudConnectionError(f"Unexpected error: {err}") from err
 


### PR DESCRIPTION
## Summary

- `KumoCloudAuthError` (raised on HTTP 403) was being silently caught by the broad `except Exception` handler in `login()` and re-wrapped as a `KumoCloudConnectionError`
- This caused HA to raise `ConfigEntryNotReady` (retry loop) instead of `ConfigEntryAuthFailed` (re-auth prompt) when a user's password is wrong or has been changed
- Fix adds `except KumoCloudError: raise` before the broad handler so auth errors propagate correctly

## Test plan

- [ ] Change your Comfort app password
- [ ] Restart HA — integration should show a re-authenticate notification instead of "Unable to connect: Unexpected error: Invalid username or password" in a retry loop
- [ ] Enter new password via the re-auth prompt — integration should reload and devices come back online

_Debugged and solution found with assistance from Claude AI._